### PR TITLE
Add Albion Online Data client package

### DIFF
--- a/config.py
+++ b/config.py
@@ -262,6 +262,8 @@ class ConfigManager:
         aodp_config = self.get_aodp_config()
         if 'base_url' not in aodp_config:
             errors.append("AODP base_url not configured")
+        if 'server' not in aodp_config:
+            errors.append("AODP server not configured")
         
         return errors
 

--- a/config.yaml
+++ b/config.yaml
@@ -36,7 +36,7 @@ crafting:
 
 # Albion Online Data Project API settings
 aodp:
-  base_url: "https://west.albion-online-data.com/api/v2/stats"
+  base_url: "https://www.albion-online-data.com/api/v2/stats"
   chunk_size: 40               # Items per API request
   rate_delay_seconds: 1        # Delay between requests
   timeout_seconds: 30          # Request timeout

--- a/config.yaml
+++ b/config.yaml
@@ -35,11 +35,12 @@ crafting:
   default_station_fee: 0       # Default station fee
 
 # Albion Online Data Project API settings
-aodp:
-  base_url: "https://www.albion-online-data.com/api/v2/stats"
-  chunk_size: 40               # Items per API request
-  rate_delay_seconds: 1        # Delay between requests
-  timeout_seconds: 30          # Request timeout
+  aodp:
+    base_url: "https://www.albion-online-data.com/api/v2/stats"
+    server: "europe"             # Target game server
+    chunk_size: 40               # Items per API request
+    rate_delay_seconds: 1        # Delay between requests
+    timeout_seconds: 30          # Request timeout
 
 # Application settings
 app:

--- a/datasources/__init__.py
+++ b/datasources/__init__.py
@@ -1,0 +1,5 @@
+"""Data source clients for Albion Trade Optimizer."""
+
+from .aodp import AODPClient, AODPAPIError
+
+__all__ = ["AODPClient", "AODPAPIError"]

--- a/datasources/aodp.py
+++ b/datasources/aodp.py
@@ -28,7 +28,9 @@ class AODPClient:
         
         # API configuration
         aodp_config = config.get('aodp', {})
-        self.base_url = aodp_config.get('base_url', 'https://west.albion-online-data.com/api/v2/stats')
+        self.base_url = aodp_config.get(
+            'base_url', 'https://www.albion-online-data.com/api/v2/stats'
+        )
         self.chunk_size = aodp_config.get('chunk_size', 40)
         self.rate_delay = aodp_config.get('rate_delay_seconds', 1)
         self.timeout = aodp_config.get('timeout_seconds', 30)


### PR DESCRIPTION
## Summary
- Move AODP client into new datasources package
- Default Albion Online Data base URL to https://www.albion-online-data.com/api/v2/stats
- Expose AODP client via datasources package

## Testing
- `pytest` (fails: SystemExit: 1 in test_gui.py)


------
https://chatgpt.com/codex/tasks/task_e_68b69d07de3c83309e33eca54916fc83